### PR TITLE
Fix reading empty headers into some typed value

### DIFF
--- a/modules/javamail/src/main/scala/emil/javamail/internal/SafeMimeMessage.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/internal/SafeMimeMessage.scala
@@ -12,18 +12,18 @@ final private[javamail] class SafeMimeMessage(msg: MimeMessage) {
   val delegate = msg
 
   def getFlags: Option[Flags] =
-    getOption("flags", msg.getFlags)
+    getOptionA("flags", msg.getFlags)
 
   def getHeader(name: String, delimiter: String): Option[String] =
     getOption(s"getHeader($name, $delimiter)", msg.getHeader(name, delimiter))
 
   def getHeader(name: String): List[String] =
-    getOption(s"getHeader($name)", msg.getHeader(name))
+    getOptionA(s"getHeader($name)", msg.getHeader(name))
       .map(_.toList)
       .getOrElse(Nil)
 
   def getSentDate: Option[Instant] =
-    getOption("Sent-Date", msg.getSentDate).map(_.toInstant)
+    getOptionA("Sent-Date", msg.getSentDate).map(_.toInstant)
 
   def getMessageID: Option[String] =
     getOption("MessageID", msg.getMessageID)
@@ -32,16 +32,16 @@ final private[javamail] class SafeMimeMessage(msg: MimeMessage) {
     getOption("Subject", msg.getSubject)
 
   def getSender: Option[Address] =
-    getOption("Sender", msg.getSender)
+    getOptionA("Sender", msg.getSender)
 
   def getFolder: Option[Folder] =
-    getOption("Folder", msg.getFolder)
+    getOptionA("Folder", msg.getFolder)
 
   def getFrom: List[Address] =
-    getOption("From", msg.getFrom).map(_.toList).getOrElse(Nil)
+    getOptionA("From", msg.getFrom).map(_.toList).getOrElse(Nil)
 
   def getRecipients(rt: Message.RecipientType): List[Address] =
-    getOption(s"Recipients($rt)", msg.getRecipients(rt))
+    getOptionA(s"Recipients($rt)", msg.getRecipients(rt))
       .map(_.toList)
       .getOrElse(Nil)
 }
@@ -52,7 +52,7 @@ private[javamail] object SafeMimeMessage {
   def apply(mm: MimeMessage): SafeMimeMessage =
     new SafeMimeMessage(mm)
 
-  def getOption[A](name: String, getter: => A): Option[A] =
+  def getOptionA[A](name: String, getter: => A): Option[A] =
     Either
       .catchNonFatal(getter)
       .fold(
@@ -62,4 +62,7 @@ private[javamail] object SafeMimeMessage {
         },
         Option.apply
       )
+
+  def getOption(name: String, getter: => String): Option[String] =
+    getOptionA(name, getter).map(_.trim).filter(_.nonEmpty)
 }

--- a/modules/javamail/src/test/resources/mails/empty-header.eml
+++ b/modules/javamail/src/test/resources/mails/empty-header.eml
@@ -1,0 +1,41 @@
+Return-Path: <max.muster@test.com>
+Delivered-To: moritz.muster@test.com
+From: Max Muster <max.muster@test.com>
+To: Max Muster <max.muster@test.com>
+Subject: Testing
+Reply-To:
+X-Something:
+Date: Thu, 23 Apr 2020 14:17:39 +0000
+Message-ID: <abc-decf-52012.test.com>
+Content-Type: multipart/mixed;
+  boundary="_007_FB9FC6347A65F54FA9C682E7356F4F0601264D75E5S52013brrabc__"
+MIME-Version: 1.0
+
+--_007_FB9FC6347A65F54FA9C682E7356F4F0601264D75E5S52013brrabc__
+Content-Type: application/pdf; name=
+  "=?utf-8?B?RWluZmFjaGUgU3ByYWNoZSAtIERpZSBUaGVyYXBpZXN0ZWxsZSDDtmZmbmV0?=
+ =?utf-8?Q?.pdf?="
+Content-Description: =?utf-8?B?RWluZmFjaGUgU3ByYWNoZSAtIERpZSBUaGVyYXBpZXN0ZWxsZSDDtmZmbmV0?=
+ =?utf-8?Q?.pdf?=
+Content-Disposition: attachment; filename=
+  "=?utf-8?B?RWluZmFjaGUgU3ByYWNoZSAtIERpZSBUaGVyYXBpZXN0ZWxsZSDDtmZmbmV0?=
+ =?utf-8?Q?.pdf?="; size=14533;
+  creation-date="Thu, 23 Apr 2020 14:12:09 GMT";
+  modification-date="Thu, 23 Apr 2020 14:10:39 GMT"
+Content-Transfer-Encoding: base64
+
+VGhpcyBpcyBvbmx5IGEgdGVzdC4=
+
+--_007_FB9FC6347A65F54FA9C682E7356F4F0601264D75E5S52013brrabc__
+Content-Type: application/pdf;
+  name="=?utf-8?B?w5ZmZm51bmcgZGVyIFRoZXJhcGllc3RlbGxlLnBkZg==?="
+Content-Description: =?utf-8?B?w5ZmZm51bmcgZGVyIFRoZXJhcGllc3RlbGxlLnBkZg==?=
+Content-Disposition: attachment;
+  filename="=?utf-8?B?w5ZmZm51bmcgZGVyIFRoZXJhcGllc3RlbGxlLnBkZg==?=";
+  size=16683; creation-date="Thu, 23 Apr 2020 14:12:14 GMT";
+  modification-date="Thu, 23 Apr 2020 14:08:58 GMT"
+Content-Transfer-Encoding: base64
+
+VGhpcyBpcyBvbmx5IGEgdGVzdC4=
+
+--_007_FB9FC6347A65F54FA9C682E7356F4F0601264D75E5S52013brrabc__--


### PR DESCRIPTION
Empty headers cannot be converted into an `InternetAddress` and
therefore ignored.

Ref: eikek/docspell#606