### PR TITLE
Hide (possibly) many tests behind one `ci` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request:
 jobs:
-  ci:
+  ci-matrix:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -21,3 +21,9 @@ jobs:
         uses: coursier/cache-action@v6
       - name: sbt ci ${{ github.ref }}
         run: sbt ci
+  ci:
+    runs-on: ubuntu-20.04
+    needs: [ci-matrix]
+    steps:
+      - name: Aggregate of lint, and all tests
+        run: echo "ci passed"


### PR DESCRIPTION
This will allow Mergify to merge Scala Steward's PRs again (like https://github.com/eikek/emil/pull/185).

Btw @eikek , you should enable Renovate bot for this repository, if you haven't done so :wink: https://app.renovatebot.com/dashboard
