### PR TITLE
Add separator to MailFolder case class

### DIFF
--- a/modules/common/src/main/scala/emil/MailFolder.scala
+++ b/modules/common/src/main/scala/emil/MailFolder.scala
@@ -2,7 +2,31 @@ package emil
 
 import cats.Hash
 
-final case class MailFolder(id: String, name: String)
+/** Structure representing one mailbox (= folder).
+  *
+  * @param id
+  *   Absolute path of the MailFolder
+  * @param name
+  *   Display name (last path segment)
+  * @param separator
+  *   Hierarchy separator
+  */
+final case class MailFolder(id: String, name: String, separator: Char) {
+
+  /** Splits the id (path) of a MailFolder in its segments using the separator.
+    *
+    * @note
+    *   Since no escaping is supported in hierarchy paths, and only one type of separator
+    *   is allowed in a hierarchy path, this is all the logic it needs to split the path
+    *   into its segments.
+    * @see
+    *   https://datatracker.ietf.org/doc/html/rfc3501#section-5.1.1
+    *
+    * @return
+    *   Separated path segments
+    */
+  def pathSegments: Array[String] = id.split(separator)
+}
 
 object MailFolder {
   implicit lazy val hash: Hash[MailFolder] = Hash.fromUniversalHashCode[MailFolder]

--- a/modules/common/src/test/scala/emil/AbstractAccessTest.scala
+++ b/modules/common/src/test/scala/emil/AbstractAccessTest.scala
@@ -34,7 +34,7 @@ abstract class AbstractAccessTest(val emil: Emil[IO]) extends GreenmailTestSuite
   test("get inbox") {
     val op: MailOp[IO, emil.C, MailFolder] = emil.access.getInbox
     val inbox = user1Imap.run(op).unsafeRunSync()
-    assertEquals(inbox, MailFolder("INBOX", "INBOX"))
+    assertEquals(inbox, MailFolder("INBOX", "INBOX", '.'))
   }
 
   test("create folder") {
@@ -42,13 +42,13 @@ abstract class AbstractAccessTest(val emil: Emil[IO]) extends GreenmailTestSuite
     val subfolder =
       user1Imap.run(emil.access.createFolder(Some(folder), "test2")).unsafeRunSync()
 
-    assertEquals(folder, MailFolder("test1", "test1"))
-    assertEquals(subfolder, MailFolder("test1.test2", "test2"))
+    assertEquals(folder, MailFolder("test1", "test1", '.'))
+    assertEquals(subfolder, MailFolder("test1.test2", "test2", '.'))
 
     val inbox = user1Imap.run(emil.access.getInbox).unsafeRunSync()
     val inboxSub =
       user1Imap.run(emil.access.createFolder(Some(inbox), "archived")).unsafeRunSync()
-    assertEquals(inboxSub, MailFolder("INBOX.archived", "archived"))
+    assertEquals(inboxSub, MailFolder("INBOX.archived", "archived", '.'))
   }
 
   test("find folder") {
@@ -354,6 +354,9 @@ abstract class AbstractAccessTest(val emil: Emil[IO]) extends GreenmailTestSuite
     val inboxFolders = user1Imap.run(makeFolders).unsafeRunSync()
     val listed = user1Imap.run(listInbox()).unsafeRunSync()
     assertEquals(listed, inboxFolders)
+
+    assertEquals(listed(0).pathSegments.toList, List("INBOX", "myfolder1"))
+    assertEquals(listed(1).pathSegments.toList, List("INBOX", "myfolder2"))
   }
 
   test("list root folders") {
@@ -368,5 +371,9 @@ abstract class AbstractAccessTest(val emil: Emil[IO]) extends GreenmailTestSuite
     val foldersWithInbox = Vector(inbox) ++ folders
     val listed = user1Imap.run(emil.access.listFolders(None)).unsafeRunSync()
     assertEquals(listed, foldersWithInbox)
+
+    assertEquals(listed(0).pathSegments.toList, List("INBOX"))
+    assertEquals(listed(1).pathSegments.toList, List("myfolder1"))
+    assertEquals(listed(2).pathSegments.toList, List("myfolder2"))
   }
 }

--- a/modules/javamail/src/main/scala/emil/javamail/conv/BasicDecode.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/conv/BasicDecode.scala
@@ -15,7 +15,7 @@ trait BasicDecode {
     Conv(flag => if (flag == Flags.Flag.FLAGGED) Some(Flag.Flagged) else None)
 
   implicit def folderConv: Conv[Folder, MailFolder] =
-    Conv(f => MailFolder(f.getFullName, f.getName))
+    Conv(f => MailFolder(f.getFullName, f.getName, f.getSeparator))
 
   implicit def mailAddressDecode: Conv[Address, MailAddress] =
     Conv {


### PR DESCRIPTION
Added the separator the IMAP server told us for each Mailbox path into the `MailFolder` case class.

This in preparation for: https://github.com/eikek/docspell/issues/1197
See in particular: https://github.com/eikek/docspell/issues/1197#issuecomment-981137051