### PR TITLE
Add full path information to MailFolder

### DIFF
--- a/modules/common/src/main/scala/emil/MailFolder.scala
+++ b/modules/common/src/main/scala/emil/MailFolder.scala
@@ -1,8 +1,18 @@
 package emil
 
 import cats.Hash
+import cats.data.NonEmptyList
 
-final case class MailFolder(id: String, name: String)
+/** Structure representing one mailbox (= folder).
+  *
+  * @param id
+  *   Absolute path of the MailFolder
+  * @param path
+  *   Path segments of the MailFolder, the last segment resembles the folder's name
+  */
+final case class MailFolder(id: String, path: NonEmptyList[String]) {
+  def name: String = path.last
+}
 
 object MailFolder {
   implicit lazy val hash: Hash[MailFolder] = Hash.fromUniversalHashCode[MailFolder]

--- a/modules/javamail/src/main/scala/emil/javamail/conv/BasicDecode.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/conv/BasicDecode.scala
@@ -2,7 +2,7 @@ package emil.javamail.conv
 
 import scala.language.postfixOps
 
-import cats.data.{Validated, ValidatedNec}
+import cats.data.{NonEmptyList, Validated, ValidatedNec}
 import cats.implicits._
 import emil._
 import emil.javamail.internal._
@@ -14,8 +14,16 @@ trait BasicDecode {
   implicit def flagDecode: Conv[Flags.Flag, Option[Flag]] =
     Conv(flag => if (flag == Flags.Flag.FLAGGED) Some(Flag.Flagged) else None)
 
+  /** The full name of the folder should never be empty, therefore
+    * NonEmptyList.fromListUnsafe is used
+    */
   implicit def folderConv: Conv[Folder, MailFolder] =
-    Conv(f => MailFolder(f.getFullName, f.getName))
+    Conv(f =>
+      MailFolder(
+        f.getFullName,
+        NonEmptyList.fromListUnsafe(f.getFullName.split(f.getSeparator).toList)
+      )
+    )
 
   implicit def mailAddressDecode: Conv[Address, MailAddress] =
     Conv {


### PR DESCRIPTION
As discussed on Matrix with @seijikun, we replaced the `MailFolder`s `name` field with a new collection of `path` segments, to surface the folder's whole path.
We added a `name` getter back that simply returns the last segment, for compatibility.

Supersedes: https://github.com/eikek/emil/pull/286