### PR TITLE
Add a method to list subfolders of a MailFolder recursively

### DIFF
--- a/modules/common/src/main/scala/emil/Access.scala
+++ b/modules/common/src/main/scala/emil/Access.scala
@@ -53,4 +53,14 @@ trait Access[F[_], C] {
   def listFolders(
       parent: Option[MailFolder]
   ): MailOp[F, C, Vector[MailFolder]]
+
+  /** List all subfolders of the optionally given @p parent folder recursively.
+    * @param parent
+    *   Optional parent folder, for which to return the recursive subfolder listing.
+    * @return
+    *   Recursive folder structure, flattened into a list of MailFolders.
+    */
+  def listFoldersRecursive(
+      parent: Option[MailFolder]
+  ): MailOp[F, C, Vector[MailFolder]]
 }

--- a/modules/javamail/src/main/scala/emil/javamail/internal/AccessImpl.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/internal/AccessImpl.scala
@@ -68,4 +68,9 @@ final class AccessImpl[F[_]: Sync] extends Access[F, JavaMailConnection] {
       parent: Option[MailFolder]
   ): MailOp[F, JavaMailConnection, Vector[MailFolder]] =
     ListFolders[F](parent)
+
+  def listFoldersRecursive(
+      parent: Option[MailFolder]
+  ): emil.MailOp[F, JavaMailConnection, Vector[MailFolder]] =
+    ListFoldersRecursive[F](parent)
 }

--- a/modules/javamail/src/main/scala/emil/javamail/internal/ops/ListFoldersRecursive.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/internal/ops/ListFoldersRecursive.scala
@@ -1,0 +1,35 @@
+package emil.javamail.internal.ops
+
+import cats.effect.Sync
+import emil.javamail.conv.Conv
+import emil.javamail.internal.JavaMailConnection
+import emil.{MailFolder, MailOp}
+import jakarta.mail.Folder
+
+object ListFoldersRecursive {
+  def apply[F[_]: Sync](parent: Option[MailFolder])(implicit
+      c: Conv[Folder, MailFolder]
+  ): MailOp[F, JavaMailConnection, Vector[MailFolder]] =
+    MailOp(conn =>
+      Sync[F].blocking {
+        listRecursive(
+          parent
+            .map(pf => conn.store.getFolder(pf.id))
+            .getOrElse(conn.store.getDefaultFolder)
+        )
+          .map(c.convert)
+          .toVector
+      }
+    )
+
+  private def listRecursive(
+      folder: Folder
+  ): List[Folder] = {
+    val list = folder.list().toList
+    if (list.isEmpty) {
+      list
+    } else {
+      list ++ list.flatMap(f => listRecursive(f))
+    }
+  }
+}


### PR DESCRIPTION
Also as discussed on Matrix with @seijikun,
here the PR that adds an implementation for recursive folder listing.

This takes an optional parent folder, and returns all folders and subfolders in the hierarchy as flattened list.
So a hierarchy:
```
- myfolder1
  - myfolder12
  - myfolder13
  - myfolder14
    - myfolder141
```

becomes this flattened sequential list:
```
- myfolder1
- myfolder1 / myfolder12
- myfolder1 / myfolder13
- myfolder1 / myfolder14
- myfolder1 / myfolder14 / myfolder141
```

Normally, IMAP supports this operation directly (`O(1)`), but `JavaMail` does not seem to provide this functionality, forcing one to traverse the hierarchy manually.