### PR TITLE
Update ci.yml, should have been 1.8, not 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ '1.8', 11, 17 ]
     steps:
       - uses: actions/checkout@v2.4.0
         with:


### PR DESCRIPTION
Otherwise it runs 11 (and not 8). Probably a bug in Jabba... oh well.