### PR TITLE
Respect custom Message-IDs in JavaMail backend

### DIFF
--- a/modules/javamail/src/main/scala/emil/javamail/internal/ops/SendMail.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/internal/ops/SendMail.scala
@@ -20,7 +20,7 @@ object SendMail {
       logger.debugF(s"Sending ${mails.size} mail(s) using ${conn.config}") *>
         mails.traverse { mail =>
           ThreadClassLoader {
-            cm.convert(conn.session, MessageIdEncode.Random, mail).flatMap { msg =>
+            cm.convert(conn.session, MessageIdEncode.GivenOrRandom, mail).flatMap { msg =>
               val msgId = checkMessageID(msg)
               Sync[F].blocking {
                 logger.debug(s"Sending message: ${infoLine(mail.header)}, $msgId")


### PR DESCRIPTION
Currently the JavaMail backend is hardcoded to ignore a custom MessageId such as in the example below:

```scala
MailBuilder.build(
  From("hello@example.com"),
  To("goodbye@example.com"),
  MessageID(s"<mycustom@example.com>"),
  Subject("Hello!"),
  TextBody("Hello!"),
)
```