### PR TITLE
JavaMail: Set Content-Description to file name

### DIFF
--- a/modules/common/src/test/scala/emil/AbstractSendTest.scala
+++ b/modules/common/src/test/scala/emil/AbstractSendTest.scala
@@ -85,7 +85,7 @@ abstract class AbstractSendTest(val emil: Emil[IO]) extends GreenmailTestSuite {
         |Content-Type: text/plain; charset=UTF-8
         |Content-Transfer-Encoding: 7bit
         |Content-Disposition: attachment; filename=test.txt
-        |Content-Description: attachment
+        |Content-Description: test.txt
         |
         |hello world!
         |------=_Part_1_272299100.1642183145458--""".stripMargin

--- a/modules/javamail/src/main/scala/emil/javamail/conv/BasicEncode.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/conv/BasicEncode.scala
@@ -59,7 +59,7 @@ trait BasicEncode {
             case None => part.setDisposition(attach.disposition.map(d => d.name).orNull)
           }
           attach.contentId.foreach(cid => part.addHeader("Content-ID", "<" + cid + ">"))
-          part.setDescription("attachment")
+          attach.filename.foreach(part.setDescription)
           part.setDataHandler(new DataHandler(new DataSource {
             def getInputStream: InputStream =
               new ByteArrayInputStream(inData)


### PR DESCRIPTION
Replace the hardcoded Content-Description "attachment" with the file name or leave blank. This brings better display in clients that interpret RFC 4021 in a strange way and use the description as the file name when displaying in UI, like MS Teams.

Alternatively, one could expose the description as a new field on `Attachment`, but that would be binary breaking.