### PR TITLE
Add support for Reply-To mail header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ target/
 local/
 _site/
 result
+.bloop
+project/**/project
+metals.sbt
+.vscode
+.metals
+.bsp

--- a/modules/common/src/main/scala/emil/builder/package.scala
+++ b/modules/common/src/main/scala/emil/builder/package.scala
@@ -57,6 +57,13 @@ package builder {
       mail.mapMailHeader(_.mapRecipients(_.addBccs(mas)))
   }
 
+  case class ReplyTo[F[_]](ma: MailAddress) extends Trans[F] {
+    def apply(mail: Mail[F]): Mail[F] =
+      mail.mapMailHeader(_.copy(replyTo = Some(ma)))
+  }
+
+  object ReplyTo extends MailAddressHelper[ReplyTo]
+
   case class Subject[F[_]](text: String) extends Trans[F] {
     def apply(mail: Mail[F]): Mail[F] =
       mail.mapMailHeader(_.withSubject(text))

--- a/modules/javamail/src/main/scala/emil/javamail/conv/BasicEncode.scala
+++ b/modules/javamail/src/main/scala/emil/javamail/conv/BasicEncode.scala
@@ -137,6 +137,9 @@ trait BasicEncode {
         Message.RecipientType.BCC,
         header.recipients.bcc.map(ca.convert).map(a => a.asInstanceOf[Address]).toArray
       )
+      msg.setReplyTo(
+        header.replyTo.map(ca.convert).map(a => a.asInstanceOf[Address]).toArray
+      )
 
       if (header.flags.nonEmpty) {
         val flags = new Flags()


### PR DESCRIPTION
Class MailHeader has already a replyTo field, however this field is currently not used in the Java Mail backend.